### PR TITLE
Remove win build from ci-build.yml

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest, macos-latest]
+        operating-system: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Currently dist generation with pybuilder fails on windows due to long path. Disabling Win build for now.