### PR TITLE
Removing __init__.py from lava/lib to avoid module clash across lava libraries

### DIFF
--- a/src/lava/lib/__init__.py
+++ b/src/lava/lib/__init__.py
@@ -1,3 +1,0 @@
-# Copyright (C) 2021 Intel Corporation
-# SPDX-License-Identifier: BSD-3-Clause
-# See: https://spdx.org/licenses/


### PR DESCRIPTION
Removing __init__.py from lava/lib to avoid module clash across lava libraries and let namespace search take care of it.