### PR TITLE
Enabling re-running of OptimizationSolver 

### DIFF
--- a/src/lava/lib/optimization/solvers/generic/solver.py
+++ b/src/lava/lib/optimization/solvers/generic/solver.py
@@ -171,11 +171,10 @@ class OptimizationSolver:
         """
         target_cost = self._validated_cost(target_cost)
         hyperparameters = hyperparameters or self.hyperparameters
-        if not self.solver_process:
-            self._create_solver_process(self.problem,
-                                        target_cost,
-                                        backend,
-                                        hyperparameters)
+        self._create_solver_process(self.problem,
+                                    target_cost,
+                                    backend,
+                                    hyperparameters)
         run_cfg = self._get_run_config(backend)
         run_condition = self._get_run_condition(timeout)
         self.solver_process._log_config.level = 20


### PR DESCRIPTION

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: enable re-running of OptimizationSolver recreating the associated process each time the `solve` method is called.

## Pull request checklist

Your PR fulfills the following requirements:
- [x] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`pyb`) passes locally
- [x] Build tests (`pyb -E unit`) or (`python -m unittest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- `OptimizationSolver.solve()` can be called only one time without re-instantiating the solver.

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- `OptimizationSolver.solve()` can be called multiple times without re-instantiation.

## Does this introduce a breaking change?

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->