### PR TITLE
Fix bug in "time_to_solution" of OptimizationSolver report 

### DIFF
--- a/src/lava/lib/optimization/solvers/generic/solver.py
+++ b/src/lava/lib/optimization/solvers/generic/solver.py
@@ -234,7 +234,7 @@ class OptimizationSolver:
         steps_to_solution = self.solver_process.solution_step.aliased_var.get()
         self._report["steps_to_solution"] = steps_to_solution
         self._report["time_to_solution"] = None if \
-            self._profiler is None else np.mean(self._profiler.execution_time)
+            self._profiler is None else np.sum(self._profiler.execution_time)
         print(self._report)
 
     def _create_solver_process(self,

--- a/src/lava/lib/optimization/solvers/generic/solver.py
+++ b/src/lava/lib/optimization/solvers/generic/solver.py
@@ -200,7 +200,6 @@ class OptimizationSolver:
                              "Loihi2 backend, got {backend}.")
 
         from lava.utils.profiler import Profiler
-        self._profiler = Loihi2HWProfiler()
         target_cost = self._validated_cost(target_cost)
         hyperparameters = hyperparameters or self.hyperparameters
         if not self.solver_process:


### PR DESCRIPTION
<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: fix bug in OptimizationSolver interface with Loihi2HwProfiler

## Pull request checklist

Your PR fulfills the following requirements:
- [x] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`pyb`) passes locally
- [x] Build tests (`pyb -E unit`) or (`python -m unittest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- The OptimizationSolver report returns the average execution time per step as the "time_to_solution".

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- Save the total execution time in the OptimizationSolver report, summing the execution times of all steps.

## Does this introduce a breaking change?

- [x] No

