### PR TITLE
Update SolverTuner behaviour with hyperparameters passed through SolverConfig

### DIFF
--- a/src/lava/lib/optimization/utils/solver_tuner.py
+++ b/src/lava/lib/optimization/utils/solver_tuner.py
@@ -97,7 +97,7 @@ class SolverTuner:
         for params in self._search_space:
             np.random.seed(self._seed)
             hyperparams = dict(zip(self._params_names, params))
-            config.hyperparameters = hyperparams
+            config.hyperparameters.update(hyperparams)
             report = solver.solve(config=config)
             self._store_trial(
                 params=hyperparams,
@@ -106,7 +106,7 @@ class SolverTuner:
                 fitness=fitness_fn(report)
             )
             if fitness_fn(report) > best_fitness:
-                best_hyperparams = hyperparams
+                best_hyperparams = config.hyperparameters.copy()
                 best_fitness = fitness_fn(report)
                 print(
                     f"Better hyperparameters configuration found!\n"

--- a/tests/lava/lib/optimization/utils/test_solver_tuner.py
+++ b/tests/lava/lib/optimization/utils/test_solver_tuner.py
@@ -24,7 +24,10 @@ def prepare_solver_and_config():
     config = SolverConfig(
         timeout=1000,
         target_cost=-11,
-        backend="CPU"
+        backend="CPU",
+        hyperparameters={
+            "neuron_model": "nebm"
+        }
     )
 
     return solver, config


### PR DESCRIPTION
Objective of pull request: make SolverTuner use the hyperparameters 

## Pull request checklist

Your PR fulfills the following requirements:
- [x] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`pyb`) passes locally
- [x] Build tests (`pyb -E unit`) or (`python -m unittest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
- [x] Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- Hyperparameters passed through the SolverConfig to the SolverTuner that are not subject to tuning are discarded

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- Hyperparameters passed through the SolverConfig to the SolverTuner that are not subject to tuning are used. This is useful, for example, to set the neuron model to be used, and in general to set default hyperparameters that don't need tuning.

## Does this introduce a breaking change?

- [x] No
