### PR TITLE
Adjusting Boltzmann/simulated annealing Vars with Loihi implementation

### DIFF
--- a/src/lava/lib/optimization/solvers/generic/nebm/models.py
+++ b/src/lava/lib/optimization/solvers/generic/nebm/models.py
@@ -27,11 +27,11 @@ class NEBMPyModel(PyLoihiProcessModel):
     temperature: np.ndarray = LavaPyType(np.ndarray, int, precision=8)
     refract: np.ndarray = LavaPyType(np.ndarray, int, precision=8)
 
+    refract_counter: np.ndarray = LavaPyType(np.ndarray, int, precision=8)
+
     def __init__(self, proc_params):
         super().__init__(proc_params)
         self.a_in_data = np.zeros(proc_params['shape'])
-
-        self.refract_buffer = np.zeros(proc_params['shape']).astype(int)
 
     def _prng(self):
         """Pseudo-random number generator
@@ -88,7 +88,7 @@ class NEBMPyModel(PyLoihiProcessModel):
                 lfsr, (2 * self.temperature + self.state)))
 
         # Neurons can only switch states outside their refractory period
-        wta_spk_idx = np.array([wta_spk_idx[ii] if self.refract_buffer[ii] <= 0
+        wta_spk_idx = np.array([wta_spk_idx[ii] if self.refract_counter[ii] <= 0
                                 else wta_spk_idx_prev[ii]
                                 for ii in range(wta_spk_idx.shape[0])])
 
@@ -105,8 +105,8 @@ class NEBMPyModel(PyLoihiProcessModel):
         s_wta[np.logical_and(wta_spk_idx_prev, np.logical_not(wta_spk_idx))] \
             = -1
 
-        self.refract_buffer = np.maximum(
-            self.refract_buffer - 1,
+        self.refract_counter = np.maximum(
+            self.refract_counter - 1,
             np.multiply(self.refract, (s_wta != 0)))
 
         # s_wta[wta_spk_idx] = 1

--- a/src/lava/lib/optimization/solvers/generic/nebm/process.py
+++ b/src/lava/lib/optimization/solvers/generic/nebm/process.py
@@ -52,6 +52,8 @@ class NEBM(AbstractProcess):
 
         self.refract = Var(shape=shape, init=refract)
 
+        self.refract_counter = Var(shape=shape, init=int(0))
+
         # Initial state determined in DiscreteVariables
         self.state = Var(shape=shape, init=init_state.astype(int))
 
@@ -116,7 +118,7 @@ class NEBMSimulatedAnnealing(AbstractProcess):
 
         self.temperature = Var(shape=shape, init=int(max_temperature))
 
-        self.refract_counter = Var(shape=shape, init=refract)
+        self.refract_counter = Var(shape=shape, init=int(0))
 
         # Initial state determined in DiscreteVariables
         self.state = Var(


### PR DESCRIPTION
Objective of pull request:
I introduced a new Var for refract_counter in the new Loihi version of SA/NEBM. Aligning lava-optim accordingly.

## Pull request checklist

Your PR fulfills the following requirements:
- [ ] [Issue](https://github.com/lava-nc/lava-optimization/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`pyb`) passes locally
- [x] Build tests (`pyb -E unit`) or (`python -m unittest`) passes locally