### PR TITLE
Deleting incorrect reference to NcProcModels (Fix Collab unit tests)

### DIFF
--- a/src/lava/lib/optimization/solvers/generic/solver.py
+++ b/src/lava/lib/optimization/solvers/generic/solver.py
@@ -31,17 +31,12 @@ from lava.proc.monitor.process import Monitor
 from lava.utils.profiler import Profiler
 
 try:
-    from lava.lib.optimization.solvers.generic.read_gate.ncmodels import \
-        ReadGateCModel
     from lava.proc.dense.ncmodels import NcModelDense
     from lava.lib.optimization.solvers.generic.nebm.ncmodels import \
         NEBMNcModel, NEBMSimulatedAnnealingNcModel
     from lava.lib.optimization.solvers.generic.cost_integrator.ncmodels \
         import CostIntegratorNcModel
 except ImportError:
-
-    class ReadGateCModel:
-        pass
 
     class NcModelDense:
         pass


### PR DESCRIPTION
Objective of pull request:
Re-enabling unit tests in Collab (Parallelization PR), which were broken as the ReadGateCModel no longer exists.

Please check your PR type:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 
