### PR TITLE
Enable cost tracking with Loihi backend (#212)

### DIFF
--- a/src/lava/lib/optimization/solvers/generic/solver.py
+++ b/src/lava/lib/optimization/solvers/generic/solver.py
@@ -252,10 +252,8 @@ class OptimizationSolver:
         num_in_ports = len(hps) if isinstance(hps, list) else 1
         if config.probe_cost:
             if config.backend in NEUROCORES:
-                # from lava.utils.loihi2_state_probes import StateProbe
-                # self._cost_tracker = StateProbe(self.solver_process.optimality
-                # )
-                raise NotImplementedError
+                from lava.utils.loihi2_state_probes import StateProbe
+                self._cost_tracker = StateProbe(self.solver_process.optimality)
             if config.backend in CPUS:
                 self._cost_tracker = Monitor()
                 self._cost_tracker.probe(


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava-optimization/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: Closes #185 

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: enable cost tracking for OptimizationSolver on Loihi backkend

## Pull request checklist

Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/lava-nc/lava-optimization/issues) created that explains the change and why it's needed
- [x] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`pyb`) passes locally
- [x] Build tests (`pyb -E unit`) or (`python -m unittest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
- [x] Feature


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- Cost tracking not enabled for Neurocore backend

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- Cost tracking enabled for Neurocore backend through the `probe_cost` variable of `SolverConfig`

## Does this introduce a breaking change?

- [x] No
