### PR TITLE
Fix refract_counter init in NEBM/NEBMSA

### DIFF
--- a/src/lava/lib/optimization/solvers/generic/nebm/process.py
+++ b/src/lava/lib/optimization/solvers/generic/nebm/process.py
@@ -52,7 +52,7 @@ class NEBM(AbstractProcess):
 
         self.refract = Var(shape=shape, init=refract)
 
-        self.refract_counter = Var(shape=shape, init=int(0))
+        self.refract_counter = Var(shape=shape, init=refract)
 
         # Initial state determined in DiscreteVariables
         self.state = Var(shape=shape, init=init_state.astype(int))
@@ -120,7 +120,13 @@ class NEBMSimulatedAnnealing(AbstractProcess):
 
         self.temperature = Var(shape=shape, init=int(max_temperature))
 
-        self.refract_counter = Var(shape=shape, init=int(0))
+        self.refract_counter = Var(
+            shape=shape,
+            init=(refract or 0)
+            + np.right_shift(
+                np.random.randint(0, 2**8, size=shape), (refract_scaling or 0)
+            ),
+        )
 
         # Initial state determined in DiscreteVariables
         self.state = Var(


### PR DESCRIPTION
Objective of pull request: fix initialization of refract_counter to match expected behaviour

## Pull request checklist

Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/lava-nc/lava-optimization/issues) created that explains the change and why it's needed
- [x] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`pyb`) passes locally
- [x] Build tests (`pyb -E unit`) or (`python -m unittest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- `refract_counter` was initialized to 0 in `NEBM` and `NEBMSA` processes, resulting in the model not entering in refractory period after the first spike

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
-`refract_counter` is correctly initialized, based on the value of `refract` and `refract_scaling`

## Does this introduce a breaking change?

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
